### PR TITLE
[api] Rename services to actions (breaking change)

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -79,8 +79,8 @@ esphome:
 
 api:
   reboot_timeout: 0s
-  services:
-    - service: play_buzzer
+  actions:
+    - action: play_buzzer
       variables:
         song_str: string
       then:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -222,6 +222,16 @@ text_sensor:
     ip_address:
       name: "IP Address"
       id: wifi_ip
+  - platform: version
+    name: "ESPHome Version"
+    hide_timestamp: true
+    entity_category: "diagnostic"
+  - platform: template
+    name: "Apollo Firmware Version"
+    id: apollo_firmware_version
+    lambda: |-
+      return {"${version}"};
+    entity_category: "diagnostic"
 
 event:
   - platform: template

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -132,8 +132,6 @@ api:
                 id: deep_sleep_1
 
 external_components:
-  - source: github://ApolloAutomation/ExternalComponents
-    components: [deep_sleep]
   - source: github://ApolloAutomation/esphome-battery-component
     components: [max17048] #Forked OptionZero
 


### PR DESCRIPTION
## Summary

- Renames `api: services:` → `api: actions:` and `service: play_buzzer` → `action: play_buzzer` in `Core.yaml`

**Breaking change:** Any Home Assistant automations or scripts that call `play_buzzer` as an ESPHome *service* must be updated to use the new *action* syntax after flashing.

## Test plan

- [ ] Confirm device compiles and flashes successfully
- [ ] Update any HA automations using `esphome.play_buzzer` service calls to the new action syntax
- [ ] Confirm action works correctly from the HA developer tools

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ESPHome Version and Apollo Firmware Version diagnostic text sensors for expanded device telemetry.
  * Buzzer action now available through the ESPHome API.

* **Changes**
  * Reorganized buzzer configuration from services to actions.
  * Updated sensor diagnostic categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->