### PR TITLE
[esphome] Modernise board spec, web server v3, remove legacy options

### DIFF
--- a/Integrations/ESPHome/BTN-1.yaml
+++ b/Integrations/ESPHome/BTN-1.yaml
@@ -25,11 +25,6 @@ update:
     source: https://apolloautomation.github.io/BTN-1/firmware/manifest.json
 
 wifi:
-  on_connect:
-    - delay: 5s
-    - ble.disable:
-  on_disconnect:
-    - ble.enable:
   ap:
     ssid: "Apollo BTN1 Hotspot"
 

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -13,7 +13,7 @@ esphome:
     name: "ApolloAutomation.BTN-1"
     version: "${version}"
 
-  min_version: 2023.11.1
+  min_version: 2025.6.0
 
   # Wake-up detection logic
   on_boot:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -9,9 +9,6 @@ esphome:
   friendly_name: Apollo BTN-1
   comment: Apollo BTN-1
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
-
   project:
     name: "ApolloAutomation.BTN-1"
     version: "${version}"
@@ -137,7 +134,6 @@ external_components:
     components: [max17048] #Forked OptionZero
 
 esp32:
-  board: esp32-c6-devkitm-1
   variant: esp32c6
   flash_size: 8MB
   framework:
@@ -159,6 +155,7 @@ captive_portal:
 web_server:
   id: web_server_instance
   port: 80
+  version: 3
 
 i2c:
   id: i2c_bus


### PR DESCRIPTION
## Summary

- Remove `platformio_options: board_build.flash_mode: dio` from the `esphome:` block in Core.yaml
- Remove redundant `esp32: board: esp32-c6-devkitm-1` string from Core.yaml (`variant: esp32c6` + `flash_size: 8MB` already present and sufficient)
- Add `version: 3` to `web_server:` in Core.yaml (inherited by all device variants)
- Remove legacy BLE wifi hooks (`on_connect: ble.disable` / `on_disconnect: ble.enable`) from BTN-1.yaml

## Test plan

- [ ] `esphome config` validates cleanly for BTN-1.yaml and BTN-1_Minimal.yaml
- [ ] OTA flash succeeds on device
- [ ] Web server UI loads at device IP

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added web server v3 support

* **Changes**
  * Simplified Wi‑Fi and Bluetooth behavior during connection events
  * Raised the minimum required platform version
  * Adjusted device build defaults
<!-- end of auto-generated comment: release notes by coderabbit.ai -->