### PR TITLE
Fix deep sleep build error: move deep_sleep.enter to script

### DIFF
--- a/.github/workflows/autoassign.yml
+++ b/.github/workflows/autoassign.yml
@@ -15,5 +15,5 @@ jobs:
       uses: pozil/auto-assign-issue@v2
       with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          assignees: TrevorSchirmer
+          assignees: bharvey88
           numOfAssignee: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           - dev
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6.0.2
       - name: Build ESPHome firmware to verify configuration
         uses: esphome/build-action@v7
         with:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -19,7 +19,7 @@ jobs:
           - dev
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v6.0.2
       - name: Build ESPHome firmware to verify configuration
         uses: esphome/build-action@v7
         with:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -709,23 +709,17 @@ script:
   
   - id: testScript
     then:
-      if: 
+      if:
         condition:
           - lambda: "return id(runTest) == true;"
         then:
           - lambda: "id(runTest) = false;"
           - lambda: "id(testCycleCount) = 0;"
-          - lambda: "id(runTest) = false;"
           - light.turn_on:
               id: rgb_light
               red: 0%
               green: 100%
               blue: 0%
           - delay: 5s
-          - light.turn_on:
-              id: rgb_light
-              red: 0%
-              green: 0%
-              blue: 0%
           - light.turn_off:
               id: rgb_light

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -713,7 +713,7 @@ script:
 
   - id: testScript
     then:
-      if:
+      - if:
         condition:
           - lambda: "return id(runTest) == true;"
         then:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -714,16 +714,16 @@ script:
   - id: testScript
     then:
       - if:
-        condition:
-          - lambda: "return id(runTest) == true;"
-        then:
-          - lambda: "id(runTest) = false;"
-          - lambda: "id(testCycleCount) = 0;"
-          - light.turn_on:
-              id: rgb_light
-              red: 0%
-              green: 100%
-              blue: 0%
-          - delay: 5s
-          - light.turn_off:
-              id: rgb_light
+          condition:
+            - lambda: "return id(runTest) == true;"
+          then:
+            - lambda: "id(runTest) = false;"
+            - lambda: "id(testCycleCount) = 0;"
+            - light.turn_on:
+                id: rgb_light
+                red: 0%
+                green: 100%
+                blue: 0%
+            - delay: 5s
+            - light.turn_off:
+                id: rgb_light

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-btn-1
-  version: "25.11.6.1"
+  version: "25.12.4.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 
@@ -71,6 +71,13 @@ esphome:
               id(wakeup_button_pressed).publish_state("0");
             }
           }
+    - priority: -10
+      then:
+        - if:
+            condition:
+              - lambda: "return id(runTest);"
+            then:
+              - lambda: "id(testScript).execute();"
           
   on_shutdown:
     - light.turn_off: rgb_light
@@ -151,6 +158,14 @@ globals:
     restore_value: no
     type: uint32_t
     initial_value: '0'
+  - id: runTest
+    restore_value: yes
+    type: bool
+    initial_value: "true"
+  - id: testCycleCount
+    type: int
+    restore_value: no
+    initial_value: "0"
 
 captive_portal:
   id: captive_portal_instance
@@ -297,9 +312,9 @@ binary_sensor:
               // StatusCheck
               id(statusCheck).execute();
               delay(3000);
-              // id(testCycleCount) = 0;
-              // id(runTest) = true;
-              // id(testScript).execute();
+              id(testCycleCount) = 0;
+              id(runTest) = true;
+              id(testScript).execute();
             }
   - platform: gpio
     id: button_1
@@ -684,3 +699,26 @@ script:
       - component.update: sys_esp_temperature
       - component.update: sys_uptime
       - component.update: wakeup_button_pressed
+  
+  - id: testScript
+    then:
+      if: 
+        condition:
+          - lambda: "return id(runTest) == true;"
+        then:
+          - lambda: "id(runTest) = false;"
+          - lambda: "id(testCycleCount) = 0;"
+          - lambda: "id(runTest) = false;"
+          - light.turn_on:
+              id: rgb_light
+              red: 0%
+              green: 100%
+              blue: 0%
+          - delay: 5s
+          - light.turn_on:
+              id: rgb_light
+              red: 0%
+              green: 0%
+              blue: 0%
+          - light.turn_off:
+              id: rgb_light

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -132,8 +132,6 @@ api:
                 id: deep_sleep_1
 
 external_components:
-  - source: github://ApolloAutomation/ExternalComponents
-    components: [deep_sleep]
   - source: github://ApolloAutomation/esphome-battery-component
     components: [max17048] #Forked OptionZero
 

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -131,12 +131,11 @@ api:
             - lambda: |- 
                 ESP_LOGW("Apollo", "Preventing Deep Sleep Due To OTA Or Switch");
                 id(deep_sleep_1).prevent_deep_sleep(); 
-          else: 
+          else:
             - lambda: |-
                 id(reportAllValues).execute();
             - delay: 2s
-            - deep_sleep.enter:
-                id: deep_sleep_1
+            - script.execute: go_to_sleep
 
 external_components:
   - source: github://ApolloAutomation/esphome-battery-component
@@ -706,7 +705,12 @@ script:
       - component.update: sys_esp_temperature
       - component.update: sys_uptime
       - component.update: wakeup_button_pressed
-  
+
+  - id: go_to_sleep
+    then:
+      - deep_sleep.enter:
+          id: deep_sleep_1
+
   - id: testScript
     then:
       if:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -297,8 +297,8 @@ binary_sensor:
         - lambda: |-
             if (millis() - id(button_press_timestamp) >= 10000) {
               // Remove Wifi
-              // id(testCycleCount) = 0;
-              // id(runTest) = true;
+              id(testCycleCount) = 0;
+              id(runTest) = true;
               id(prevent_sleep).turn_on();
               id(factory_reset_switch).turn_on();
             }

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-btn-1
-  version: "25.12.4.1"
+  version: "25.12.5.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 
@@ -280,7 +280,7 @@ binary_sensor:
     name: Online
     id: ink_ha_connected
   - platform: gpio
-    pin: 
+    pin:
       number: GPIO9
       inverted: true
       mode:
@@ -288,34 +288,41 @@ binary_sensor:
         pullup: true
       ignore_strapping_warning: true
     id: reset_button
-    on_press:
-      then:
-        - lambda: |-
-            id(button_press_timestamp) = millis();    
-    on_release:
-      then:
-        - lambda: |-
-            if (millis() - id(button_press_timestamp) >= 10000) {
-              // Remove Wifi
-              id(testCycleCount) = 0;
-              id(runTest) = true;
-              id(prevent_sleep).turn_on();
-              id(factory_reset_switch).turn_on();
-            }
-            else if (millis() - id(button_press_timestamp) >= 3000) {
-              //Turn Prevent Sleep On
-              id(prevent_sleep).turn_on();
-              //Prevent Sleep
+    on_multi_click:
+      - timing:
+          - ON for at least 10s
+        then:
+          # Factory reset (10s hold)
+          - globals.set:
+              id: testCycleCount
+              value: "0"
+          - globals.set:
+              id: runTest
+              value: "true"
+          - switch.turn_on: prevent_sleep
+          - switch.turn_on: factory_reset_switch
+      - timing:
+          - ON for at least 3s
+          - OFF for at least 0.2s
+        then:
+          # Prevent sleep (3s hold)
+          - switch.turn_on: prevent_sleep
+          - lambda: |-
               id(deep_sleep_1).prevent_deep_sleep();
-            }
-            else {
-              // StatusCheck
-              id(statusCheck).execute();
-              delay(3000);
-              id(testCycleCount) = 0;
-              id(runTest) = true;
-              // id(testScript).execute();1
-            }
+      - timing:
+          - ON for at most 1s
+          - OFF for at least 0.2s
+        then:
+          # Short press - run status check then test script
+          - script.execute: statusCheck
+          - delay: 3s
+          - globals.set:
+              id: testCycleCount
+              value: "0"
+          - globals.set:
+              id: runTest
+              value: "true"
+          - script.execute: testScript
   - platform: gpio
     id: button_1
     name: "Button 1"

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -314,7 +314,7 @@ binary_sensor:
               delay(3000);
               id(testCycleCount) = 0;
               id(runTest) = true;
-              id(testScript).execute();
+              // id(testScript).execute();1
             }
   - platform: gpio
     id: button_1


### PR DESCRIPTION
Version: 25.12.5.1

## What does this implement/fix?

Fixes build failure where `deep_sleep.enter` inside `api.on_client_connected` caused
`EnterDeepSleepAction<std::string, std::string>` to be instantiated as an abstract type.
Routes deep sleep entry through a new `go_to_sleep` script which has no inherited
template parameters, fixing the compile error.

## Types of changes

- [x] Bugfix (fixed change that fixes an issue)

## Checklist / Checklijst:

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced button interactions with multi-click support for various actions including factory reset and test mode.
  * Added new test functionality with configurable test execution capabilities.
  * Improved sleep management with updated script handling.

* **Chores**
  * Updated GitHub Actions checkout versions for CI and weekly workflows.
  * Updated workflow assignee configuration.
  * Bumped ESPHome version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->