### PR TITLE
Fix Apollo Firmware Version sensor showing unknown

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -19,6 +19,9 @@ esphome:
   on_boot:
     - priority: 500
       then:
+        - text_sensor.template.publish:
+            id: apollo_firmware_version
+            state: "${version}"
         - lambda: |-
             id(deep_sleep_1).set_sleep_duration(id(deep_sleep_sleep_duration).state * 60 * 60 * 1000);
         - if:
@@ -109,9 +112,6 @@ api:
 
       # Send Wake up Button State
       - component.update: wakeup_button_pressed
-      - text_sensor.template.publish:
-          id: apollo_firmware_version
-          state: "${version}"
 
       # Check OTA Switch
       - delay: 3s
@@ -227,8 +227,7 @@ text_sensor:
   - platform: template
     name: "Apollo Firmware Version"
     id: apollo_firmware_version
-    lambda: |-
-      return {"${version}"};
+    update_interval: never
     entity_category: "diagnostic"
 
 event:
@@ -698,6 +697,3 @@ script:
       - component.update: sys_esp_temperature
       - component.update: sys_uptime
       - component.update: wakeup_button_pressed
-      - text_sensor.template.publish:
-          id: apollo_firmware_version
-          state: "${version}"

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -109,7 +109,9 @@ api:
 
       # Send Wake up Button State
       - component.update: wakeup_button_pressed
-      - component.update: apollo_firmware_version
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"
 
       # Check OTA Switch
       - delay: 3s
@@ -227,7 +229,6 @@ text_sensor:
     id: apollo_firmware_version
     lambda: |-
       return {"${version}"};
-    update_interval: never
     entity_category: "diagnostic"
 
 event:
@@ -697,4 +698,6 @@ script:
       - component.update: sys_esp_temperature
       - component.update: sys_uptime
       - component.update: wakeup_button_pressed
-      - component.update: apollo_firmware_version
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"


### PR DESCRIPTION
## What does this implement/fix?

Fixes Apollo Firmware Version text sensor showing "unknown" in Home Assistant.

- Replaced `component.update` with `text_sensor.template.publish` for the version sensor in both `on_client_connected` and `reportAllValues` script
- Removed `update_interval: never` so the lambda also fires periodically (every 60s) as a fallback

The root cause is that ESPHome's `component.update` action silently skips execution when the component's `is_ready()` check fails (see `UpdateComponentAction::play()` in `esphome/core/base_automation.h`). The `text_sensor.template.publish` action calls `publish_state()` directly without this guard.

Same fix as ApolloAutomation/AIR-1#87

## Types of changes

- [x] Bugfix (fixed change that fixes an issue)

## Checklist / Checklijst:

  - [x] The code change has been tested and works locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced firmware version sensor responsiveness in ESPHome integration by refactoring how version changes are communicated and detected across system states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->