### PR TITLE
Release 26.3.2.1 - New sensors, ESPHome modernisation, and bug fixes

### DIFF
--- a/Integrations/ESPHome/BTN-1.yaml
+++ b/Integrations/ESPHome/BTN-1.yaml
@@ -25,11 +25,6 @@ update:
     source: https://apolloautomation.github.io/BTN-1/firmware/manifest.json
 
 wifi:
-  on_connect:
-    - delay: 5s
-    - ble.disable:
-  on_disconnect:
-    - ble.enable:
   ap:
     ssid: "Apollo BTN1 Hotspot"
 

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -219,7 +219,7 @@ text_sensor:
   - platform: wifi_info
     ip_address:
       name: "IP Address"
-      id: wifi_ip
+      entity_category: "diagnostic"
 
 event:
   - platform: template

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -79,8 +79,8 @@ esphome:
 
 api:
   reboot_timeout: 0s
-  services:
-    - service: play_buzzer
+  actions:
+    - action: play_buzzer
       variables:
         song_str: string
       then:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -224,6 +224,7 @@ text_sensor:
     name: "ESPHome Version"
     hide_timestamp: true
     entity_category: "diagnostic"
+    entity_category: "diagnostic"
   - platform: template
     name: "Apollo Firmware Version"
     id: apollo_firmware_version

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -222,6 +222,16 @@ text_sensor:
     ip_address:
       name: "IP Address"
       id: wifi_ip
+  - platform: version
+    name: "ESPHome Version"
+    hide_timestamp: true
+    entity_category: "diagnostic"
+  - platform: template
+    name: "Apollo Firmware Version"
+    id: apollo_firmware_version
+    lambda: |-
+      return {"${version}"};
+    entity_category: "diagnostic"
 
 event:
   - platform: template

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -13,7 +13,7 @@ esphome:
     name: "ApolloAutomation.BTN-1"
     version: "${version}"
 
-  min_version: 2023.11.1
+  min_version: 2025.6.0
 
   # Wake-up detection logic
   on_boot:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -9,9 +9,6 @@ esphome:
   friendly_name: Apollo BTN-1
   comment: Apollo BTN-1
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
-
   project:
     name: "ApolloAutomation.BTN-1"
     version: "${version}"
@@ -137,7 +134,6 @@ external_components:
     components: [max17048] #Forked OptionZero
 
 esp32:
-  board: esp32-c6-devkitm-1
   variant: esp32c6
   flash_size: 8MB
   framework:
@@ -159,6 +155,7 @@ captive_portal:
 web_server:
   id: web_server_instance
   port: 80
+  version: 3
 
 i2c:
   id: i2c_bus

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -19,6 +19,9 @@ esphome:
   on_boot:
     - priority: 500
       then:
+        - text_sensor.template.publish:
+            id: apollo_firmware_version
+            state: "${version}"
         - lambda: |-
             id(deep_sleep_1).set_sleep_duration(id(deep_sleep_sleep_duration).state * 60 * 60 * 1000);
         - if:
@@ -109,9 +112,6 @@ api:
 
       # Send Wake up Button State
       - component.update: wakeup_button_pressed
-      - text_sensor.template.publish:
-          id: apollo_firmware_version
-          state: "${version}"
 
       # Check OTA Switch
       - delay: 3s
@@ -227,8 +227,7 @@ text_sensor:
   - platform: template
     name: "Apollo Firmware Version"
     id: apollo_firmware_version
-    lambda: |-
-      return {"${version}"};
+    update_interval: never
     entity_category: "diagnostic"
 
 event:
@@ -698,6 +697,3 @@ script:
       - component.update: sys_esp_temperature
       - component.update: sys_uptime
       - component.update: wakeup_button_pressed
-      - text_sensor.template.publish:
-          id: apollo_firmware_version
-          state: "${version}"

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -219,6 +219,7 @@ text_sensor:
   - platform: wifi_info
     ip_address:
       name: "IP Address"
+      id: wifi_ip
       entity_category: "diagnostic"
 
 event:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -109,7 +109,9 @@ api:
 
       # Send Wake up Button State
       - component.update: wakeup_button_pressed
-      - component.update: apollo_firmware_version
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"
 
       # Check OTA Switch
       - delay: 3s
@@ -227,7 +229,6 @@ text_sensor:
     id: apollo_firmware_version
     lambda: |-
       return {"${version}"};
-    update_interval: never
     entity_category: "diagnostic"
 
 event:
@@ -697,4 +698,6 @@ script:
       - component.update: sys_esp_temperature
       - component.update: sys_uptime
       - component.update: wakeup_button_pressed
-      - component.update: apollo_firmware_version
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -224,7 +224,6 @@ text_sensor:
     name: "ESPHome Version"
     hide_timestamp: true
     entity_category: "diagnostic"
-    entity_category: "diagnostic"
   - platform: template
     name: "Apollo Firmware Version"
     id: apollo_firmware_version

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -132,8 +132,6 @@ api:
                 id: deep_sleep_1
 
 external_components:
-  - source: github://ApolloAutomation/ExternalComponents
-    components: [deep_sleep]
   - source: github://ApolloAutomation/esphome-battery-component
     components: [max17048] #Forked OptionZero
 

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-btn-1
-  version: "25.11.6.1"
+  version: "26.3.2.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -112,6 +112,7 @@ api:
 
       # Send Wake up Button State
       - component.update: wakeup_button_pressed
+      - component.update: apollo_firmware_version
 
       # Check OTA Switch
       - delay: 3s
@@ -699,3 +700,4 @@ script:
       - component.update: sys_esp_temperature
       - component.update: sys_uptime
       - component.update: wakeup_button_pressed
+      - component.update: apollo_firmware_version

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -218,6 +218,10 @@ text_sensor:
     id: wakeup_button_pressed
     name: "Wake-up Button Pressed"
     icon: "mdi:gesture-tap-button"
+  - platform: wifi_info
+    ip_address:
+      name: "IP Address"
+      id: wifi_ip
 
 event:
   - platform: template

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -230,6 +230,7 @@ text_sensor:
     id: apollo_firmware_version
     lambda: |-
       return {"${version}"};
+    update_interval: never
     entity_category: "diagnostic"
 
 event:


### PR DESCRIPTION
<!--
From Core.yaml. Should match date YY.MM.DD.# ( Usually # is 1 )
-->
Version: 26.3.2.1

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## What does this implement/fix?

Merges beta into main for the 26.3.2.1 release. Changes include:

- **ESPHome modernisation** — web server v3, remove redundant board string (variant + flash_size already present), remove legacy BLE on_connect/on_disconnect wifi hooks, set `min_version: 2025.6.0` to enforce web server v3 compatibility *(breaking: board spec change)*
- **API services → actions rename** — `play_buzzer` and other services renamed to actions *(breaking: existing HA automations calling these services will need updating)*
- **Remove custom deep_sleep external component** — incompatible with current ESPHome automation API
- **IP address text sensor** — via `wifi_info` platform
- **ESPHome version + Apollo firmware version text sensors**
- **Bug fixes** — Apollo firmware version showing "unknown", firmware version now published once on boot instead of polling

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [x] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [x] Added/updated documentation for the web page

<!--
  Thank you for contributing <3
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diagnostic sensors for firmware version, Wi-Fi IP address, and ESPHome version information.

* **Bug Fixes**
  * Simplified Wi-Fi configuration by removing automatic BLE toggling on connectivity changes.

* **Chores**
  * Updated firmware to version 26.3.2.1 and increased minimum ESPHome version requirement.
  * Updated web server to version 3.
  * Modified buzzer API command structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->